### PR TITLE
General cleanup, Linux support

### DIFF
--- a/Tournament/BotRobotPlayer.hpp
+++ b/Tournament/BotRobotPlayer.hpp
@@ -24,7 +24,7 @@ public:
 
 		int toDo = 3;
 
-		for (int i = 0; i < sizeof(options)/sizeof(std::string); i++) {
+		for (int i = 0; i < int(sizeof(options)/sizeof(*options)); i++) {
 			if (options[i].compare(action) == 0) {
 				toDo = outputs[i];
 				break;

--- a/Tournament/CMakeLists.txt
+++ b/Tournament/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project(tournament)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 if(CMAKE_COMPILER_IS_GNUCXX)
     add_definitions(-Wall -Wextra -Wno-unused-parameter)
 endif()

--- a/Tournament/CMakeLists.txt
+++ b/Tournament/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+project(tournament)
+set(CMAKE_CXX_STANDARD 14)
+if(CMAKE_COMPILER_IS_GNUCXX)
+    add_definitions(-Wall -Wextra -Wno-unused-parameter)
+endif()
+add_executable(tournament Tournament.cpp)

--- a/Tournament/DeceptivePlayer.hpp
+++ b/Tournament/DeceptivePlayer.hpp
@@ -28,7 +28,7 @@ public:
 		}
 
 		// Every 10 turns the Deceiver goes crazy
-		if (turn % 10)
+                if (turn % 10 || opponentAmmo>=3)
 		{
 			// Generate random integer in [0, 5)
 			int random = GetRandomInteger() % 5;

--- a/Tournament/Player.hpp
+++ b/Tournament/Player.hpp
@@ -40,6 +40,8 @@ public:
 		case PLASMA:
 			mAmmoOpponent -= 2;
 			break;
+                default:
+                        break;
 		}
 	}
 

--- a/Tournament/ProxyPlayer.hpp
+++ b/Tournament/ProxyPlayer.hpp
@@ -11,8 +11,11 @@
 
 #ifdef _WIN32
 #undef UNICODE
-#define NOMINMAX
-#include <Windows.h>
+#ifdef NOMINMAX
+#undef NOMINMAX
+#endif
+#define NOMINMAX 1
+#include <windows.h>
 #define EXE_SUFFIX ".exe"
 #else
 #include <cstdlib>

--- a/Tournament/ProxyPlayer.hpp
+++ b/Tournament/ProxyPlayer.hpp
@@ -116,8 +116,6 @@ private:
 	}
 };
 
-#define STRINGIFY(x) #x
-
 // Example: BINARY_PLAYER(CustomPlayer)
 // Effects: Invoke CustomPlayer.exe <arguments>
 #define BINARY_PLAYER(x)                                              \

--- a/Tournament/ProxyPlayer.hpp
+++ b/Tournament/ProxyPlayer.hpp
@@ -9,9 +9,15 @@
 #include <string>
 #include <sstream>
 
+#ifdef _WIN32
 #undef UNICODE
 #define NOMINMAX
 #include <Windows.h>
+#define EXE_SUFFIX ".exe"
+#else
+#include <cstdlib>
+#define EXE_SUFFIX ""
+#endif
 
 class ProxyPlayer : public Player
 {
@@ -76,6 +82,7 @@ private:
 	// Execute process with given arguments.
 	unsigned executeWithArguments(std::string const &arguments) const
 	{
+#ifdef _WIN32
 		STARTUPINFO startup = { sizeof(startup) };
 		PROCESS_INFORMATION process;
 		LPSTR lpApplicationName;
@@ -113,6 +120,9 @@ private:
 			GetExitCodeProcess(process.hProcess, &exitCode);
 			return exitCode;
 		}
+#else
+		return std::system((mProcess + " " + mScript + " " + arguments).c_str());
+#endif
 	}
 };
 
@@ -122,7 +132,7 @@ private:
 	class x final : public ProxyPlayer                                \
 	{                                                                 \
 	public:                                                           \
-		x(size_t opponent = -1) : ProxyPlayer(#x ".exe", opponent) {} \
+	    x(size_t opponent = -1) : ProxyPlayer(#x EXE_SUFFIX, opponent) {} \
 	};
 
 // Example: SCRIPT_PLAYER(CustomPlayer, "python", "CustomScriptPlayer.py")

--- a/Tournament/ProxyPlayer.hpp
+++ b/Tournament/ProxyPlayer.hpp
@@ -18,7 +18,7 @@ class ProxyPlayer : public Player
 public:
 	// Initialize with process (without .exe) and identifier of opponent.
 	ProxyPlayer(std::string const &process, std::string const &script = "", size_t opponent = -1)
-		: mProcess(process), mScript(script), Player(opponent) {}
+	    : Player(opponent), mProcess(process), mScript(script) {}
 
 public:
 	// Invoke other process.

--- a/Tournament/ProxyPlayer.hpp
+++ b/Tournament/ProxyPlayer.hpp
@@ -24,7 +24,7 @@ public:
 	// Invoke other process.
 	virtual Action fight()
 	{
-		DWORD choice = executeWithArguments(getArguments(3));
+		unsigned choice = executeWithArguments(getArguments(3));
 		switch (choice)
 		{
 		case 48: return load();
@@ -74,7 +74,7 @@ private:
 	}
 
 	// Execute process with given arguments.
-	DWORD executeWithArguments(std::string const &arguments) const
+	unsigned executeWithArguments(std::string const &arguments) const
 	{
 		STARTUPINFO startup = { sizeof(startup) };
 		PROCESS_INFORMATION process;

--- a/Tournament/SadisticShooterPlayer.hpp
+++ b/Tournament/SadisticShooterPlayer.hpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include "Player.hpp"
 #include <iostream>
-#include <conio.h>
 #include "GunDuel.hpp"
 
 

--- a/Tournament/Tournament.cpp
+++ b/Tournament/Tournament.cpp
@@ -12,6 +12,7 @@
 #include "PlasmaPlayer.hpp"
 #include "SadisticShooterPlayer.hpp"
 #include "DeceptivePlayer.hpp"
+#include <iostream>
 
 // Tournament pool of all valid entries.
 class Pool final
@@ -44,5 +45,7 @@ int main()
 	Tournament<Pool> tournament(repetition);
 	tournament.run();
 
-	system("pause");
+    std::cout<<"Press Enter to quit... ";
+    std::cin.ignore();
+    return 0;
 }

--- a/Tournament/Tournament.cpp
+++ b/Tournament/Tournament.cpp
@@ -14,6 +14,18 @@
 #include "DeceptivePlayer.hpp"
 #include <iostream>
 
+// Support C++11
+#if __cplusplus > 201103L
+using std::make_unique;
+#else
+namespace {
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+}
+#endif
+
 // Tournament pool of all valid entries.
 class Pool final
 {
@@ -22,14 +34,14 @@ public:
 	{
 		switch (index)
 		{
-		case 0: return std::make_unique<GunClubPlayer>(opponent);
-		case 1: return std::make_unique<OpportunistPlayer>(opponent);
-		case 2: return std::make_unique<TurtlePlayer>(opponent);
-		case 3: return std::make_unique<BarricadePlayer>(opponent);
-		case 4: return std::make_unique<BotRobotPlayer>(opponent);
-		case 5: return std::make_unique<PlasmaPlayer>(opponent);
-		case 6: return std::make_unique<SadisticShooterPlayer>(opponent);
-		case 7: return std::make_unique<DeceptivePlayer>(opponent);
+		case 0: return make_unique<GunClubPlayer>(opponent);
+		case 1: return make_unique<OpportunistPlayer>(opponent);
+		case 2: return make_unique<TurtlePlayer>(opponent);
+		case 3: return make_unique<BarricadePlayer>(opponent);
+		case 4: return make_unique<BotRobotPlayer>(opponent);
+		case 5: return make_unique<PlasmaPlayer>(opponent);
+		case 6: return make_unique<SadisticShooterPlayer>(opponent);
+		case 7: return make_unique<DeceptivePlayer>(opponent);
 		default: return nullptr;
 		}
 	}

--- a/Tournament/Tournament.hpp
+++ b/Tournament/Tournament.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <random>
 #include <iostream>
+#include <cassert>
 
 // Class responsible for a tournament.
 template <class Pool>
@@ -109,6 +110,8 @@ private:
 		case GunDuel::BWIN:
 			mScores[b].point += 1;
 			mScores[b].pointTotal += 1;
+			break;
+		case GunDuel::DRAW:
 			break;
 		}
 	}

--- a/Tournament/Tournament.hpp
+++ b/Tournament/Tournament.hpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <algorithm>
 #include <limits>
-#include <numeric>>
+#include <numeric>
 #include <chrono>
 #include <random>
 

--- a/Tournament/Tournament.hpp
+++ b/Tournament/Tournament.hpp
@@ -68,7 +68,6 @@ public:
 	// Run the tournament!
 	void run()
 	{
-		size_t round = 0;
 		while (getPlayerRemaining() > 1)
 		{
 			startRound();

--- a/Tournament/Tournament.hpp
+++ b/Tournament/Tournament.hpp
@@ -16,6 +16,7 @@
 #include <numeric>
 #include <chrono>
 #include <random>
+#include <iostream>
 
 // Class responsible for a tournament.
 template <class Pool>


### PR DESCRIPTION
General cleanup of the sources to be able to compile them without errors (and with minimal warnings) with gcc on Linux.
Added a brutal platform-agnostic implementation of ProxyPlayer.hpp (previously Windows-only).
Added CMakeLists.txt for platfrom-agnostic compilation.